### PR TITLE
Don't bother with strnlen if width is less than or equal to 0

### DIFF
--- a/stl/inc/ostream
+++ b/stl/inc/ostream
@@ -652,8 +652,8 @@ template class _CRTIMP2_PURE_IMPORT basic_ostream<unsigned short, char_traits<un
 template <class _Elem, class _Traits>
 basic_ostream<_Elem, _Traits>& operator<<(basic_ostream<_Elem, _Traits>& _Ostr, const char* _Val) { // insert NTBS
     ios_base::iostate _State = ios_base::goodbit;
-    streamsize _Count        = static_cast<streamsize>(_CSTD strlen(_Val));
-    streamsize _Pad          = _Ostr.width() <= 0 || _Ostr.width() <= _Count ? 0 : _Ostr.width() - _Count;
+    streamsize _Count;
+    streamsize _Pad          = _Ostr.width() <= 0 || _Ostr.width() == (_Count = static_cast<streamsize>(_CSTD strnlen(_Val, static_cast<size_t>(_Ostr.width())))) ? 0 : _Ostr.width() - _Count;
     const typename basic_ostream<_Elem, _Traits>::sentry _Ok(_Ostr);
 
     if (!_Ok) {


### PR DESCRIPTION
<!--
Before submitting a pull request, please ensure that:

* Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.

* These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).

* Your changes are written from scratch using only this repository, the C++
  Working Draft (including any cited standards), other WG21 papers (excluding
  reference implementations outside of proposed standard wording), and LWG
  issues as reference material. If your changes are derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If your changes are derived from any other project, you *must* mention it
  here, so we can determine whether the license is compatible and what else
  needs to be done.
-->
